### PR TITLE
Auth: Preparing auth for multiple clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compile ratpack.dependency('h2')
     compile ratpack.dependency('hikari')
     compile ratpack.dependency('pac4j')
+    compile ratpack.dependency('remote')
     compile 'org.pac4j:pac4j-http:1.5.1'
     compile 'org.pac4j:pac4j-oauth:1.5.1'
 

--- a/src/main/groovy/com/cellarhq/auth/AuthPathAuthorizer.groovy
+++ b/src/main/groovy/com/cellarhq/auth/AuthPathAuthorizer.groovy
@@ -28,7 +28,8 @@ class AuthPathAuthorizer extends AbstractAuthorizer {
             'forgot-password',
             /styles\/.*/,
             /images\/.*/,
-            /pac4j.*/
+            /pac4j.*/,
+            /favicon\.ico/
     ]
 
     @Override

--- a/src/main/groovy/com/cellarhq/auth/CellarHQAuthenticationHandler.groovy
+++ b/src/main/groovy/com/cellarhq/auth/CellarHQAuthenticationHandler.groovy
@@ -1,0 +1,76 @@
+package com.cellarhq.auth
+
+import groovy.transform.CompileStatic
+import org.pac4j.core.client.Clients
+import org.pac4j.core.exception.RequiresHttpAction
+import org.pac4j.core.exception.TechnicalException
+import org.pac4j.core.profile.UserProfile
+import ratpack.handling.Context
+import ratpack.http.Request
+import ratpack.pac4j.Authorizer
+import ratpack.pac4j.internal.Pac4jProfileHandler
+import ratpack.pac4j.internal.RatpackWebContext
+import ratpack.session.store.SessionStorage
+
+/**
+ * Filters requests to apply authentication and authorization as required.
+ *
+ * Unlike the ratpack-pac4j authentication handler, this handler will derive the client used for authentication on the
+ * request URI. If an authentication client cannot be determined, a TechnicalException will be thrown.
+ */
+@SuppressWarnings('VariableName')
+@CompileStatic
+class CellarHQAuthenticationHandler extends Pac4jProfileHandler {
+
+    // From the ratpack-pac4j internals class SessionConstants
+    private final static String SAVED_URI = 'ratpack.pac4j-saved-uri'
+
+    private final Authorizer authorizer
+
+    CellarHQAuthenticationHandler(Authorizer authorizer) {
+        this.authorizer = authorizer
+    }
+
+    @Override
+    void handle(final Context context) {
+        UserProfile userProfile = getUserProfile(context)
+        if (authorizer.isAuthenticationRequired(context) && userProfile == null) {
+            initiateAuthentication(context)
+        } else {
+            if (userProfile != null) {
+                registerUserProfile(context, userProfile)
+                authorizer.handleAuthorization(context, userProfile)
+            } else {
+                context.next()
+            }
+        }
+    }
+
+    private void initiateAuthentication(final Context context) throws Exception {
+        final Request request = context.request
+        request.get(SessionStorage).put(SAVED_URI, request.uri)
+        final Clients clients = request.get(Clients)
+        final RatpackWebContext webContext = new RatpackWebContext(context)
+
+        context.blocking {
+            clients.findClient(deriveClient(request.path, webContext)).redirect(webContext, true, false)
+        } onError { Throwable ex ->
+            if (ex instanceof RequiresHttpAction) {
+                webContext.sendResponse((RequiresHttpAction) ex)
+            } else {
+                throw new TechnicalException('Failed to redirect', ex)
+            }
+        } then {
+            webContext.sendResponse()
+        }
+    }
+
+    private String deriveClient(String path, RatpackWebContext webContext) throws RequiresHttpAction {
+        if (path.startsWith('auth-twitter')) {
+            return 'TwitterClient'
+        } else if (path.startsWith('auth-form')) {
+            return 'FormClient'
+        }
+        throw RequiresHttpAction.redirect('Unauthorized to view this page', webContext, '/login')
+    }
+}

--- a/src/main/groovy/com/cellarhq/auth/SecurityModule.groovy
+++ b/src/main/groovy/com/cellarhq/auth/SecurityModule.groovy
@@ -1,29 +1,70 @@
 package com.cellarhq.auth
 
 import com.google.inject.AbstractModule
+import com.google.inject.Injector
 import com.google.inject.Provides
 import com.google.inject.Singleton
 import com.google.inject.TypeLiteral
 import groovy.transform.CompileStatic
 import org.pac4j.core.client.Client
 import org.pac4j.http.client.FormClient
+import org.pac4j.http.credentials.SimpleTestUsernamePasswordAuthenticator
 import org.pac4j.http.credentials.UsernamePasswordAuthenticator
 import org.pac4j.http.credentials.UsernamePasswordCredentials
 import org.pac4j.http.profile.HttpProfile
+import org.pac4j.oauth.client.TwitterClient
+import org.pac4j.oauth.credentials.OAuthCredentials
+import org.pac4j.oauth.profile.twitter.TwitterProfile
+import ratpack.guice.HandlerDecoratingModule
+import ratpack.handling.Handler
+import ratpack.handling.Handlers
+import ratpack.launch.LaunchConfig
 import ratpack.pac4j.Authorizer
+import ratpack.pac4j.internal.Pac4jCallbackHandler
+import ratpack.pac4j.internal.Pac4jClientsHandler
 
 @CompileStatic
-class SecurityModule extends AbstractModule {
+class SecurityModule extends AbstractModule implements HandlerDecoratingModule {
+
+    private static final String DEFAULT_CALLBACK_PATH = 'pac4j-callback'
+
     @Override
     protected void configure() {
-        bind(UsernamePasswordAuthenticator).to(CellarHQUsernamePasswordAuthenticator)
+        bind(UsernamePasswordAuthenticator).to(SimpleTestUsernamePasswordAuthenticator)
         bind(Authorizer).to(AuthPathAuthorizer)
         bind(new TypeLiteral<Client<UsernamePasswordCredentials, HttpProfile>>() {}).to(FormClient)
+        bind(new TypeLiteral<Client<OAuthCredentials, TwitterProfile>>() {}).to(TwitterClient)
     }
 
     @Singleton
     @Provides
     FormClient formClient(UsernamePasswordAuthenticator authenticator) {
         new FormClient('/login', authenticator)
+    }
+
+    @Singleton
+    @Provides
+    TwitterClient twitterClient() {
+        new TwitterClient('jnvxx2qjluMFdJN5dt4xRw', 'IPRGbYPFlEqfSHFdaNxQtOc755HnGVIGrqpOHWXmI')
+    }
+
+    private String getCallbackPath(Injector injector) {
+        LaunchConfig launchConfig = injector.getInstance(LaunchConfig)
+        return launchConfig.getOther('pac4j.callbackPath', DEFAULT_CALLBACK_PATH)
+    }
+
+    @SuppressWarnings('VariableName')
+    @Override
+    Handler decorate(Injector injector, Handler handler) {
+        final String callbackPath = getCallbackPath(injector)
+        final Authorizer authorizer = injector.getInstance(Authorizer)
+        final TwitterClient twitterClient = injector.getInstance(TwitterClient)
+        final FormClient formClient = injector.getInstance(FormClient)
+        final Pac4jClientsHandler clientsHandler = new Pac4jClientsHandler(callbackPath, twitterClient, formClient)
+        final Pac4jCallbackHandler callbackHandler = new Pac4jCallbackHandler()
+        final CellarHQAuthenticationHandler authenticationHandler = new CellarHQAuthenticationHandler(authorizer)
+
+        return Handlers.chain(clientsHandler,
+                              Handlers.path(callbackPath, callbackHandler), authenticationHandler, handler)
     }
 }

--- a/src/main/groovy/com/cellarhq/endpoints/TwitterLoginEndpoint.groovy
+++ b/src/main/groovy/com/cellarhq/endpoints/TwitterLoginEndpoint.groovy
@@ -16,6 +16,8 @@ import org.pac4j.oauth.profile.twitter.TwitterProfile
 import ratpack.groovy.handling.GroovyContext
 import ratpack.groovy.handling.GroovyHandler
 
+import java.time.LocalDateTime
+
 /**
  * Endpoint for the Twitter login.
  *
@@ -56,7 +58,7 @@ class TwitterLoginEndpoint extends GroovyHandler {
                                 location = twitterProfile.location
                                 website = twitterProfile.profileUrl
                                 bio = twitterProfile.description
-                                lastLogin = new Date()
+                                lastLogin = LocalDateTime.now()
 
                                 // TODO Photo
 

--- a/src/main/groovy/com/cellarhq/endpoints/YourCellarEndpoint.groovy
+++ b/src/main/groovy/com/cellarhq/endpoints/YourCellarEndpoint.groovy
@@ -1,0 +1,25 @@
+package com.cellarhq.endpoints
+
+import static ratpack.groovy.Groovy.groovyMarkupTemplate
+
+import org.pac4j.core.profile.UserProfile
+import ratpack.groovy.handling.GroovyContext
+import ratpack.groovy.handling.GroovyHandler
+
+class YourCellarEndpoint extends GroovyHandler {
+
+    @Override
+    protected void handle(GroovyContext context) {
+        context.with {
+            byMethod {
+                get {
+                    UserProfile profile = request.get(UserProfile)
+                    render groovyMarkupTemplate('yourcellar.gtpl',
+                            username: profile.username,
+                            title: 'Your Cellar',
+                            loggedIn: true)
+                }
+            }
+        }
+    }
+}

--- a/src/ratpack/templates/_login-form.gtpl
+++ b/src/ratpack/templates/_login-form.gtpl
@@ -6,7 +6,7 @@ if (error) {
 }
 
 div {
-    a(href: '/login-twitter', id: 'twitter-login-btn') {
+    a(href: '/auth-twitter', id: 'twitter-login-btn') {
         img(src: '/images/sign-in-with-twitter-gray.png', alt: 'Sign in with Twitter'){}
     }
 }

--- a/src/test/groovy/com/cellarhq/functional/specs/TwitterAuthFunctionalSpec.groovy
+++ b/src/test/groovy/com/cellarhq/functional/specs/TwitterAuthFunctionalSpec.groovy
@@ -73,7 +73,7 @@ class TwitterAuthFunctionalSpec extends GebReportingSpec {
 
         then:
         page.twitterLoginLink.displayed
-        page.twitterLoginLink.@href.endsWith('/login-twitter')
+        page.twitterLoginLink.@href.endsWith('/auth-twitter')
     }
 
     def 'accessing twitter login endpoint logs a user in and sends them to Your Cellar'() {


### PR DESCRIPTION
Given some pretty basic testing, it looks like this will get us support for multiple authentication clients. It isn't ideal, but it's the best I could come up with. The Pac4j module maintainer was only able to get clients to work by custom bootstrapping all of the clients into chains attached to specific prefixes. Not really what we're aiming for. 

In `CellarHQAuthenticationHandler`, we check the request path against what we know to be the auth client gateways and select the client by name that way. Anything that doesn't fall in-line will be auto-flagged as unauthorized and they'll be redirected to `/login`.

cc @kyleboon 
