### PR TITLE
Hibernate: Updating JSR 310 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
     compile databaseDriver
     compile 'org.hibernate:hibernate-core:4.3.5.Final'
-    compile 'com.github.marschall:threeten-jpa:1.0.1'
+    compile 'org.jadira.usertype:usertype.extended:3.2.0.GA'
 
     compile 'org.mindrot:jbcrypt:0.3m'
     compile 'com.github.slugify:slugify:2.1.2'

--- a/src/main/groovy/com/cellarhq/domain/CellaredDrink.groovy
+++ b/src/main/groovy/com/cellarhq/domain/CellaredDrink.groovy
@@ -10,6 +10,7 @@ import javax.persistence.Id
 import javax.persistence.Index
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Entity(name = 'cellared_drink', indexes = [
@@ -34,7 +35,7 @@ class CellaredDrink extends AbstractEntity {
     Style style
 
     @Column(name = 'bottle_date', nullable = true)
-    Date bottleDate
+    LocalDate bottleDate
 
     @Column(nullable = true)
     String size

--- a/src/main/groovy/com/cellarhq/domain/Organization.groovy
+++ b/src/main/groovy/com/cellarhq/domain/Organization.groovy
@@ -16,7 +16,7 @@ import javax.persistence.JoinColumn
 import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.UniqueConstraint
-
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Entity(name = 'organization', uniqueConstraints = [
@@ -48,7 +48,7 @@ class Organization extends AbstractEntity {
     String description
 
     @Column(nullable = true)
-    Date established
+    LocalDate established
 
     @Column(length = 20, nullable = true)
     String phone

--- a/src/main/groovy/com/cellarhq/ratpack/hibernate/SessionFactoryProvider.groovy
+++ b/src/main/groovy/com/cellarhq/ratpack/hibernate/SessionFactoryProvider.groovy
@@ -1,8 +1,5 @@
 package com.cellarhq.ratpack.hibernate
 
-import com.github.marschall.threeten.jpa.LocalDateConverter
-import com.github.marschall.threeten.jpa.LocalDateTimeConverter
-import com.github.marschall.threeten.jpa.LocalTimeConverter
 import com.google.common.collect.Sets
 import com.google.inject.Inject
 import com.google.inject.Provider
@@ -68,6 +65,8 @@ class SessionFactoryProvider implements Provider<SessionFactory> {
             setProperty(AvailableSettings.ORDER_INSERTS, 'true')
             setProperty(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS, 'true')
             setProperty('jadira.usertype.autoRegisterUserTypes', 'true')
+            setProperty('jadira.usertype.javaZone', 'UTC')
+            setProperty('jadira.usertype.databaseZone', 'UTC')
 
             if (hikariConfig.dataSourceClassName == 'org.h2.jdbcx.JdbcDataSource') {
                 log.warn('H2 DataSource: Auto-generating DDL')
@@ -76,10 +75,6 @@ class SessionFactoryProvider implements Provider<SessionFactory> {
             } else {
                 setProperty('hibernate.dialect', 'org.hibernate.dialect.PostgreSQL9Dialect')
             }
-
-            addAnnotatedClass(LocalTimeConverter)
-            addAnnotatedClass(LocalDateConverter)
-            addAnnotatedClass(LocalDateTimeConverter)
         }
 
         addAnnotatedClasses(configuration, annotatedEntities.entities)


### PR DESCRIPTION
Found some bugs with JSR 310 and Hibernate. This doesn't fix everything, but I wanted to separate it from the auth work I'm doing.

For some reason, Hibernate fails flushes because jadira is trying to map the timezone offset into the LocalDateTime objects. This doesn't make a whole lot of sense to me... This is still outstanding, might just move to jodatime and avoid the issue - wanted to get a PR out in case you have thoughts.

cc @kyleboon 
