### PR TITLE
MISC: Cleaning up layout a bit

### DIFF
--- a/src/main/groovy/com/cellarhq/handlebars/HandlebarsTemplateRendererImpl.groovy
+++ b/src/main/groovy/com/cellarhq/handlebars/HandlebarsTemplateRendererImpl.groovy
@@ -27,6 +27,7 @@ class HandlebarsTemplateRendererImpl extends HandlebarsTemplateRenderer {
     private final static String MODEL_PAGE_ID = 'pageId'
     private final static String MODEL_TITLE = 'title'
     private final static String MODEL_LOGGED_IN = 'loggedIn'
+    private final static String MODEL_PAGE_URI = 'pageUri'
 
     @Inject
     HandlebarsTemplateRendererImpl(Handlebars handlebars) {
@@ -48,6 +49,10 @@ class HandlebarsTemplateRendererImpl extends HandlebarsTemplateRenderer {
         if (!model.containsKey(MODEL_TITLE)) {
             logMissingVariable(MODEL_TITLE, context.request.uri)
             model[MODEL_TITLE] = DEFAULT_TITLE
+        }
+
+        if (!model.containsKey(MODEL_PAGE_URI)) {
+            model[MODEL_PAGE_URI] = "/${context.request.path}"
         }
 
         model[MODEL_LOGGED_IN] = SessionUtil.isLoggedIn(context.request.maybeGet(CommonProfile))

--- a/src/ratpack/handlebars/breweries/edit.html.hbs
+++ b/src/ratpack/handlebars/breweries/edit.html.hbs
@@ -1,16 +1,7 @@
+{{# partial "header" }}
+  <h1>Brewery Management</h1>
+{{/partial}}
 {{# partial "content" }}
-    <div class="content-header">
-        <div class="row">
-            <div class="col-sm-6">
-                <div class="header-section">
-                    <h1>Brewery Management</h1>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    {{>common/messages}}
-
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
             <div class="block">

--- a/src/ratpack/handlebars/breweries/list.html.hbs
+++ b/src/ratpack/handlebars/breweries/list.html.hbs
@@ -1,16 +1,8 @@
+{{# partial "header" }}
+  <h1>Breweries</h1>
+{{/partial}}
+
 {{# partial "content" }}
-    <div class="content-header">
-        <div class="row">
-            <div class="col-sm-6">
-                <div class="header-section">
-                    <h1>Breweries</h1>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    {{>common/messages}}
-
     <div class="block full">
         <div class="row">
             <div class="input-group col-md-6">
@@ -54,26 +46,7 @@
                     </tbody>
                 </table>
 
-                {{#pagination this currentPage totlalPageCount 5}}
-                    <ul class="pagination">
-                        {{#if canGoPrevious}}
-                            <li class="prev"><a href="/breweries?page={{previousIdx}}">Prev</a></li>
-                        {{else}}
-                            <li class="prev disabled"><a href="#">Prev</a></li>
-                        {{/if}}
-
-                        {{#each pages}}
-                            <li {{#if isCurrent}}class="active"{{/if}}><a href="/breweries?page={{page}}">{{page}}</a>
-                            </li>
-                        {{/each}}
-
-                        {{#if canGoNext}}
-                            <li class="next"><a href="/breweries?page={{nextIdx}}">Next</a></li>
-                        {{else}}
-                            <li class="next disabled"><a href="#">Next</a></li>
-                        {{/if}}
-                    </ul>
-                {{/pagination}}
+                {{>common/pagination}}
 
             </div>
         </div>

--- a/src/ratpack/handlebars/breweries/new.html.hbs
+++ b/src/ratpack/handlebars/breweries/new.html.hbs
@@ -1,16 +1,7 @@
+{{# partial "header" }}
+  <h1>Brewery Management</h1>
+{{/partial}}
 {{# partial "content" }}
-    <div class="content-header">
-        <div class="row">
-            <div class="col-sm-6">
-                <div class="header-section">
-                    <h1>Brewery Management</h1>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    {{>common/messages}}
-
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
             <div class="block">

--- a/src/ratpack/handlebars/breweries/show.html.hbs
+++ b/src/ratpack/handlebars/breweries/show.html.hbs
@@ -1,16 +1,7 @@
+{{# partial "header" }}
+  <h1>Brewery Management</h1>
+{{/partial}}
 {{# partial "content" }}
-    <div class="content-header">
-        <div class="row">
-            <div class="col-sm-6">
-                <div class="header-section">
-                    <h1>Brewery Management</h1>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    {{>common/messages}}
-
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
             <div class="block">

--- a/src/ratpack/handlebars/change-password.html.hbs
+++ b/src/ratpack/handlebars/change-password.html.hbs
@@ -1,8 +1,7 @@
-{{# partial "content" }}
+{{# partial "header" }}
   <h1>Change Password</h1>
-
-  {{>common/messages}}
-
+{{/partial}}
+{{# partial "content" }}
   <form id="change-password-form" class='form-horizontal' role='form' method='post' action='{{action}}'>
     <div class='form-group'>
       <label for='password' class='col-sm-2'>

--- a/src/ratpack/handlebars/common/pagination.hbs
+++ b/src/ratpack/handlebars/common/pagination.hbs
@@ -1,0 +1,23 @@
+{{#pagination this currentPage totalPageCount 5}}
+  <ul class="pagination">
+      {{#if canGoPrevious}}
+        <li class="prev"><a href="{{pageUri}}?page={{previousIdx}}">Prev</a></li>
+      {{else}}
+        <li class="prev disabled"><a href="#">Prev</a></li>
+      {{/if}}
+
+      {{#each pages}}
+          {{#if isCurrent}}
+            <li class="active"><a href="#">{{page}}</a></li>
+          {{else}}
+            <li><a href="{{pageUri}}?page={{page}}">{{page}}</a></li>
+          {{/if}}
+      {{/each}}
+
+      {{#if canGoNext}}
+        <li class="next"><a href="{{pageUri}}?page={{nextIdx}}">Next</a></li>
+      {{else}}
+        <li class="next disabled"><a href="#">Next</a></li>
+      {{/if}}
+  </ul>
+{{/pagination}}

--- a/src/ratpack/handlebars/forgot-password.html.hbs
+++ b/src/ratpack/handlebars/forgot-password.html.hbs
@@ -1,8 +1,7 @@
+{{# partial "header" }}
+  <h1>Forgot Password</h1>
+{{/partial}}
 {{# partial "content" }}
-    <h1>Forgot Password</h1>
-
-    {{>common/messages}}
-
     <form id="forgot-password-form" class='form-horizontal' role='form' method='post' action='{{action}}'>
       <div class='form-group'>
         <label for='email' class='col-sm-2'>

--- a/src/ratpack/handlebars/index.html.hbs
+++ b/src/ratpack/handlebars/index.html.hbs
@@ -1,7 +1,8 @@
+{{# partial "header" }}
+  <h1>Ratpack</h1>
+  <p>a micro web framework for Java &amp; Groovy</p>
+{{/partial}}
 {{# partial "content" }}
-    <h1>Ratpack</h1>
-    <p>a micro web framework for Java &amp; Groovy</p>
-    {{>common/messages}}
     <section>
       <h1>{{title}}</h1>
         <p>This is the main page for your Ratpack app.</p>

--- a/src/ratpack/handlebars/layout.html.hbs
+++ b/src/ratpack/handlebars/layout.html.hbs
@@ -96,6 +96,18 @@
             <!-- END Left Header Navigation -->
         </header>
         <div id="page-content">
+          <div class="content-header">
+            <div class="row">
+              <div class="col-sm-6">
+                <div class="header-section">
+                  {{#block "header"}}{{/block}}
+                </div>
+              </div>
+            </div>
+          </div>
+
+            {{>common/messages}}
+
             {{#block "content" }}
             {{/block}}
         </div>

--- a/src/ratpack/handlebars/login.html.hbs
+++ b/src/ratpack/handlebars/login.html.hbs
@@ -1,11 +1,7 @@
+{{# partial "header" }}
+  <h1>Login</h1>
+{{/partial}}
 {{# partial "content" }}
-    <h1>Login</h1>
-    <div class="alert alert-info" style="white-spac:pre">
-        A matching username and password will pass authentication
-    </div>
-
-    {{>common/messages}}
-
     <div>
       <a href='/auth-twitter' id='twitter-login-btn'>
         <img src='/images/sign-in-with-twitter-gray.png' alt='Sign in with Twitter'/>

--- a/src/ratpack/handlebars/register.html.hbs
+++ b/src/ratpack/handlebars/register.html.hbs
@@ -1,8 +1,7 @@
+{{# partial "header" }}
+  <h1>Register</h1>
+{{/partial}}
 {{# partial "content" }}
-    <h1>Register</h1>
-
-    {{>common/messages}}
-    
     <div>
       <a href='/auth-twitter' id='twitter-login-btn'>
         <img src='/images/sign-in-with-twitter-gray.png' alt='Sign in with Twitter'/>

--- a/src/ratpack/handlebars/settings.html.hbs
+++ b/src/ratpack/handlebars/settings.html.hbs
@@ -1,6 +1,7 @@
+{{#partial "header"}}
+  <h1>Settings</h1>
+{{/partial}}
 {{#partial "content"}}
-<h1>Settings</h1>
-    {{>common/messages}}
     <h2>Profile</h2>
     <form id="settings-form" class="form-horizontal" role="form" method="post" action="{{action}}">
       <div class="form-group">

--- a/src/ratpack/handlebars/yourcellar.html.hbs
+++ b/src/ratpack/handlebars/yourcellar.html.hbs
@@ -1,5 +1,7 @@
+{{# partial "header" }}
+  <h1>Your Cellar</h1>
+{{/partial}}
 {{# partial "content" }}
-    <h1>Your Cellar</h1>
     <h2>YOU ARE DEFINITELY PROBABLY {{username}}</h2>
 {{/partial}}
 


### PR DESCRIPTION
I made a few breaking changes to the layouts:
1. Pagination is now generic: Just include the common element and the rest will take care of itself. You can change the URL it paginates on by setting a different value for `pageUri`.
2. Moved header code to the layout
3. Moved messages to the layout

cc @kyleboon 
