### PR TITLE
Updating the session limits

### DIFF
--- a/web/src/ratpack/Ratpack.groovy
+++ b/web/src/ratpack/Ratpack.groovy
@@ -77,7 +77,7 @@ ratpack {
         add new RemoteControlModule()
 
         add new SessionModule()
-        add new MapSessionsModule(10, 5)
+        add new MapSessionsModule(100, 30)
         add new SecurityModule()
 
         add new HandlebarsModule()


### PR DESCRIPTION
100 max sessions; 30 minute timeout. Can't wait to support RDS- or ElastiCache-backed sessions.
