### PR TITLE
Added a remember me token.

### DIFF
--- a/web/src/main/groovy/com/cellarhq/api/services/CellarService.groovy
+++ b/web/src/main/groovy/com/cellarhq/api/services/CellarService.groovy
@@ -61,13 +61,17 @@ class CellarService extends BaseJooqService {
 
     rx.Observable<Cellar> get(Long id) {
         observe(execControl.blocking {
-            jooq { DSLContext create ->
-                create.select()
+            getBlocking(id)
+        }).asObservable()
+    }
+
+    Cellar getBlocking(Long id) {
+        jooq { DSLContext create ->
+            create.select()
                     .from(CELLAR)
                     .where(CELLAR.ID.eq(id))
                     .fetchOneInto(Cellar)
-            }
-        }).asObservable()
+        }
     }
 
     rx.Observable<Cellar> findBySlug(String slug) {
@@ -149,15 +153,6 @@ class CellarService extends BaseJooqService {
                 select.fetchOneInto(Integer)
             }
         })
-    }
-
-    Cellar getBlocking(Long id) {
-        (Cellar) jooq { DSLContext create ->
-            create.select()
-                    .from(CELLAR)
-                    .where(CELLAR.ID.eq(id))
-                    .fetchOneInto(Cellar)
-        }
     }
 
     Cellar saveBlocking(Cellar cellar, UploadedFile photo = null) {

--- a/web/src/main/groovy/com/cellarhq/auth/RememberMeFlag.groovy
+++ b/web/src/main/groovy/com/cellarhq/auth/RememberMeFlag.groovy
@@ -1,0 +1,5 @@
+package com.cellarhq.auth
+
+class RememberMeFlag {
+    boolean rememberMe
+}

--- a/web/src/main/groovy/com/cellarhq/auth/callbacks/AuthFailCallback.groovy
+++ b/web/src/main/groovy/com/cellarhq/auth/callbacks/AuthFailCallback.groovy
@@ -1,5 +1,6 @@
 package com.cellarhq.auth.callbacks
 
+import com.cellarhq.auth.rememberme.RememberMeService
 import com.cellarhq.util.LogUtil
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -11,6 +12,13 @@ import java.util.function.BiConsumer
 @Slf4j
 @CompileStatic
 class AuthFailCallback<C extends Context, E extends Throwable> implements BiConsumer<C, E> {
+
+    private final RememberMeService rememberMeService
+
+    AuthFailCallback(RememberMeService remembermeService) {
+        this.rememberMeService = remembermeService
+    }
+
     @Override
     void accept(C context, E throwable) {
         if (throwable.message == 'name cannot be blank')  {
@@ -22,6 +30,8 @@ class AuthFailCallback<C extends Context, E extends Throwable> implements BiCons
                     msg: throwable.message]))
 
         }
+
+        rememberMeService.loginFail(context.request, context.response)
 
         throw new TechnicalException('Failed to get user profile', throwable)
 

--- a/web/src/main/groovy/com/cellarhq/auth/callbacks/AuthSuccessCallback.groovy
+++ b/web/src/main/groovy/com/cellarhq/auth/callbacks/AuthSuccessCallback.groovy
@@ -26,5 +26,7 @@ class AuthSuccessCallback<C extends Context, P extends UserProfile> implements B
                     type: profile.getClass().name
             ]))
         }
+
+
     }
 }

--- a/web/src/main/groovy/com/cellarhq/auth/callbacks/DefaultSuccessCallback.groovy
+++ b/web/src/main/groovy/com/cellarhq/auth/callbacks/DefaultSuccessCallback.groovy
@@ -1,19 +1,28 @@
 package com.cellarhq.auth.callbacks
 
+import com.cellarhq.auth.RememberMeFlag
 import com.cellarhq.auth.AuthenticationModule
 import com.cellarhq.domain.Cellar
+import com.cellarhq.auth.rememberme.RememberMeService
 import groovy.transform.CompileStatic
-import org.pac4j.core.profile.UserProfile
+import org.pac4j.core.profile.CommonProfile
+import ratpack.form.Form
 import ratpack.handling.Context
 import ratpack.http.Request
 import ratpack.session.store.SessionStorage
 
 @CompileStatic
-class DefaultSuccessCallback<C extends Context, P extends UserProfile> {
+class DefaultSuccessCallback<C extends Context, P extends CommonProfile> {
 
     protected final static String USER_PROFILE = 'ratpack.pac4j-user-profile'
     protected final static String SAVED_URI = 'ratpack.pac4j-saved-uri'
     protected final static String DEFAULT_REDIRECT_URI = '/yourcellar'
+
+    RememberMeService rememberMeService
+
+    DefaultSuccessCallback(RememberMeService rememberMeService) {
+        this.rememberMeService = rememberMeService
+    }
 
     void defaultBehavior(C context, P profile, Cellar cellar) {
         Request request = context.request
@@ -30,6 +39,16 @@ class DefaultSuccessCallback<C extends Context, P extends UserProfile> {
         if (!originalUri) {
             originalUri = DEFAULT_REDIRECT_URI
         }
+
+        boolean shouldRememberMe = false
+        if (context.request.headers['content-type'] == 'application/x-www-form-urlencoded') {
+            final Form FORM = context.parse(Form)
+            shouldRememberMe = FORM.get('remember-me')
+        }
+
+        RememberMeFlag rememberMe = new RememberMeFlag(rememberMe: shouldRememberMe as boolean)
+
+        rememberMeService.onLoginSuccess(context.request, context.response, rememberMe, profile)
         context.redirect(originalUri)
     }
 }

--- a/web/src/main/groovy/com/cellarhq/auth/callbacks/HttpCallback.groovy
+++ b/web/src/main/groovy/com/cellarhq/auth/callbacks/HttpCallback.groovy
@@ -1,7 +1,8 @@
 package com.cellarhq.auth.callbacks
 
-import com.cellarhq.common.Messages
 import com.cellarhq.auth.AuthenticationModule
+import com.cellarhq.auth.rememberme.RememberMeService
+import com.cellarhq.common.Messages
 import com.cellarhq.domain.EmailAccount
 import com.cellarhq.auth.services.AccountService
 import com.cellarhq.api.services.CellarService
@@ -25,11 +26,13 @@ class HttpCallback<C extends Context, P extends HttpProfile> implements BiConsum
 
     private final AccountService accountService
     private final CellarService cellarService
+    private final RememberMeService rememberMeService
 
     @Inject
-    HttpCallback(AccountService accountService, CellarService cellarService) {
+    HttpCallback(AccountService accountService, CellarService cellarService, RememberMeService rememberMeService) {
         this.accountService = accountService
         this.cellarService = cellarService
+        this.rememberMeService = rememberMeService
     }
 
     @Override
@@ -57,7 +60,7 @@ class HttpCallback<C extends Context, P extends HttpProfile> implements BiConsum
             context.redirect('/logout')
         } then { EmailAccount emailAccount ->
             request.get(SessionStorage).put(AuthenticationModule.SESSION_CELLAR_ID, emailAccount.cellarId)
-            new DefaultSuccessCallback().defaultBehavior(context, profile, emailAccount.cellar)
+            new DefaultSuccessCallback(rememberMeService).defaultBehavior(context, profile, emailAccount.cellar)
         }
     }
 }

--- a/web/src/main/groovy/com/cellarhq/auth/callbacks/TwitterCallback.groovy
+++ b/web/src/main/groovy/com/cellarhq/auth/callbacks/TwitterCallback.groovy
@@ -1,5 +1,6 @@
 package com.cellarhq.auth.callbacks
 
+import com.cellarhq.auth.rememberme.RememberMeService
 import com.cellarhq.common.Messages
 import com.cellarhq.auth.AuthenticationModule
 import com.cellarhq.domain.Cellar
@@ -29,15 +30,18 @@ class TwitterCallback<C extends Context, P extends TwitterProfile> implements Bi
 
     private final AccountService accountService
     private final CellarService cellarService
+    private final RememberMeService rememberMeService
     private final TwitterAccountVerificationService verificationService
 
     @Inject
     TwitterCallback(AccountService accountService,
                     CellarService cellarService,
-                    TwitterAccountVerificationService verificationService) {
+                    TwitterAccountVerificationService verificationService,
+                    RememberMeService rememberMeService) {
 
         this.accountService = accountService
         this.cellarService = cellarService
+        this.rememberMeService = rememberMeService
         this.verificationService = verificationService
     }
 
@@ -119,7 +123,7 @@ class TwitterCallback<C extends Context, P extends TwitterProfile> implements Bi
         } then { OAuthAccount oAuthAccount ->
             if (oAuthAccount) {
                 sessionStorage.put(AuthenticationModule.SESSION_CELLAR_ID, oAuthAccount.cellarId)
-                new DefaultSuccessCallback().defaultBehavior(context, profile, oAuthAccount.cellar)
+                new DefaultSuccessCallback(rememberMeService).defaultBehavior(context, profile, oAuthAccount.cellar)
             } else {
                 // If we don't have an account, that means there was a screen name conflict. We'll still give them a
                 // session, but it won't be capable of doing a whole lot.

--- a/web/src/main/groovy/com/cellarhq/auth/rememberme/InvalidCookieException.groovy
+++ b/web/src/main/groovy/com/cellarhq/auth/rememberme/InvalidCookieException.groovy
@@ -1,0 +1,8 @@
+package com.cellarhq.auth.rememberme
+
+
+class InvalidCookieException extends RuntimeException {
+    InvalidCookieException(String s) {
+        super(s)
+    }
+}

--- a/web/src/main/groovy/com/cellarhq/auth/rememberme/RememberMeHandler.groovy
+++ b/web/src/main/groovy/com/cellarhq/auth/rememberme/RememberMeHandler.groovy
@@ -1,0 +1,28 @@
+package com.cellarhq.auth.rememberme
+
+import groovy.util.logging.Slf4j
+import org.pac4j.core.profile.UserProfile
+import ratpack.handling.Context
+import ratpack.pac4j.internal.Pac4jProfileHandler
+
+@Slf4j
+class RememberMeHandler extends Pac4jProfileHandler {
+    private final RememberMeService rememberMeService
+
+    public RememberMeHandler(RememberMeService rememberMeService) {
+        this.rememberMeService = rememberMeService
+    }
+
+    @Override
+    public void handle(final Context context) throws Exception {
+        UserProfile userProfile = getUserProfile(context)
+
+        context.blocking {
+            if (userProfile == null) {
+                rememberMeService.autoLogin(context)
+            }
+        }.then {
+            context.next()
+        }
+    }
+}

--- a/web/src/main/groovy/com/cellarhq/auth/rememberme/RememberMeService.groovy
+++ b/web/src/main/groovy/com/cellarhq/auth/rememberme/RememberMeService.groovy
@@ -1,0 +1,249 @@
+package com.cellarhq.auth.rememberme
+
+import com.cellarhq.auth.AuthenticationModule
+import com.cellarhq.auth.PasswordService
+import com.cellarhq.api.services.CellarService
+import com.cellarhq.auth.RememberMeFlag
+import com.cellarhq.auth.callbacks.DefaultSuccessCallback
+import com.cellarhq.common.CellarHQConfig
+import com.cellarhq.domain.Cellar
+import com.google.inject.Inject
+import groovy.util.logging.Slf4j
+import io.netty.handler.codec.http.Cookie
+import org.mindrot.jbcrypt.BCrypt
+import org.pac4j.core.profile.CommonProfile
+import ratpack.handling.Context
+import ratpack.http.Request
+import ratpack.http.Response
+import ratpack.session.store.SessionStorage
+
+/**
+ * Most of this code originally comes from Spring Security, The algorithm has been modified slightly
+ * to not include the users password in the hashed cookie.
+ *
+ * Essentially a cookie is created when a user logs in with the format:
+ *
+ * USERNAME:TIMESTAMP:SECRETHASH
+ *
+ * The secret hash is username:tokenExpiryTime:key
+ *
+ * When a user comes back to the sight and the token is present, if the secret hash for the given username matches, then
+ * we log in the user automatically.
+ *
+ * @author Luke Taylor
+ * @since 2.0
+ */
+@Slf4j
+public class RememberMeService {
+
+    public static final int TWO_WEEKS_S = 1209600
+
+    final static String COOKIE_NAME = 'CELLARHQ_REMEMBER_ME'
+    final static String DELIMITER = ':'
+    
+    private final String KEY
+
+    private final CellarService cellarService
+
+    @Inject
+    RememberMeService(CellarService cellarService, CellarHQConfig cellarHQConfig) {
+        this.cellarService = cellarService
+        this.KEY = cellarHQConfig.secretRememberMeToken
+    }
+
+    void autoLogin(Context context) {
+        String rememberMeCookie = extractRememberMeCookie(context.request)
+
+        if (!rememberMeCookie) {
+            log.debug('NO Remember-me cookie detected')
+            return
+        }
+
+        log.debug('Remember-me cookie detected')
+
+        if (rememberMeCookie.length() == 0) {
+            log.debug('Cookie was empty')
+            cancelCookie(context.request, context.response)
+            return
+        }
+
+        try {
+            String[] cookieTokens = decodeCookie(rememberMeCookie)
+            processAutoLoginCookie(cookieTokens, context)
+            log.debug('Remember-me cookie accepted')
+        } catch (InvalidCookieException invalidCookie) {
+            log.debug("Invalid remember-me cookie: ${invalidCookie.message}")
+            cancelCookie(context.request, context.response)
+        }
+    }
+
+    void onLoginSuccess(Request request, Response response, RememberMeFlag rememberMeFlag, CommonProfile profile) {
+        if (!rememberMeFlag.rememberMe) {
+            return
+        }
+
+        String cellarId = request.get(SessionStorage)?.get(AuthenticationModule.SESSION_CELLAR_ID)?.toString()
+
+        // If unable to find a username and password, just abort as TokenBasedRememberMeServices is
+        // unable to construct a valid token in this case.
+        if (!cellarId) {
+            log.debug('Unable to retrieve username')
+            return
+        }
+
+        int tokenLifetime = TWO_WEEKS_S
+        long expiryTime = System.currentTimeMillis()
+        // SEC-949
+        expiryTime += 1000L * (tokenLifetime < 0 ? TWO_WEEKS_S : tokenLifetime)
+
+        String unhashedSignature = makeTokenSignature(expiryTime, cellarId)
+        String hashedSignature = BCrypt.hashpw(unhashedSignature, BCrypt.gensalt(PasswordService.BCRYPT_LOG_ROUNDS))
+
+        setCookie([cellarId, Long.toString(expiryTime), hashedSignature], tokenLifetime, request, response)
+
+        log.debug("Added remember-me cookie for user '${cellarId}', expiry: '${new Date(expiryTime)}'")
+    }
+
+    final void loginFail(Request request, Response response) {
+        log.debug('Interactive login attempt was unsuccessful.')
+        cancelCookie(request, response)
+    }
+
+    void processAutoLoginCookie(String[] cookieTokens, Context context) {
+        if (cookieTokens.length != 3) {
+            throw new InvalidCookieException(
+                    "Cookie token did not contain 3 tokens, but contained '${Arrays.asList(cookieTokens)}'")
+        }
+
+        long tokenExpiryTime
+
+        try {
+            tokenExpiryTime = new Long(cookieTokens[1]).longValue()
+        } catch (NumberFormatException nfe) {
+            throw new InvalidCookieException(
+                    "Cookie token[1] did not contain a valid number (contained '${cookieTokens[1]}')")
+        }
+
+        if (isTokenExpired(tokenExpiryTime)) {
+            throw new InvalidCookieException('Cookie token[1] has expired (expired on \''
+                    + new Date(tokenExpiryTime) + '; current time is \'' + new Date() + '\')')
+        }
+
+        Long cellarId = Long.parseLong(cookieTokens[0])
+
+        Cellar cellar = cellarService.getBlocking(cellarId)
+        String expectedTokenSignature = makeTokenSignature(tokenExpiryTime, cellar.id.toString())
+
+        if (!BCrypt.checkpw(expectedTokenSignature, cookieTokens[2])) {
+            String warning = "Cookie token contained '${cookieTokens[2]}' but expected '${expectedTokenSignature}'"
+            log.warn(warning)
+            throw new InvalidCookieException(warning)
+        }
+
+        CommonProfile profile = new CommonProfile()
+        profile.setId(cellar.screenName)
+        profile.addAttribute(CommonProfile.USERNAME, cellar.screenName)
+
+        log.debug('trying to add profile to session')
+        Request request = context.request
+        SessionStorage sessionStorage = request.get(SessionStorage)
+        sessionStorage.put(DefaultSuccessCallback.USER_PROFILE, profile)
+        sessionStorage.put(AuthenticationModule.SESSION_CELLAR_ID, cellar.id)
+        log.debug('profile added to session')
+
+    }
+
+    /**
+     * Calculates the digital signature to be put in the cookie.
+     */
+    protected String makeTokenSignature(long tokenExpiryTime, String username) {
+        return "$username:$tokenExpiryTime:$KEY"
+    }
+
+    protected boolean isTokenExpired(long tokenExpiryTime) {
+        return tokenExpiryTime < System.currentTimeMillis()
+    }
+
+
+    String[] decodeCookie(String cookieValue) {
+        String newCookieValue = cookieValue
+        for (int j = 0; j < newCookieValue.length() % 4; j++) {
+            newCookieValue = newCookieValue + '='
+        }
+
+        String cookieAsPlainText
+        try {
+            cookieAsPlainText = new String(Base64.decoder.decode(newCookieValue.bytes))
+        } catch (IllegalArgumentException ex) {
+            throw new InvalidCookieException("Cookie token was not Base64 encoded; value was '$newCookieValue'")
+        }
+
+        String[] tokens = cookieAsPlainText.split(DELIMITER)
+
+        if ((tokens[0].equalsIgnoreCase('http') || tokens[0].equalsIgnoreCase('https')) && tokens[1].startsWith('//')) {
+            // Assume we've accidentally split a URL (OpenID identifier)
+            String[] newTokens = new String[tokens.length - 1]
+            newTokens[0] = tokens[0] + DELIMITER + tokens[1]
+            System.arraycopy(tokens, 2, newTokens, 1, newTokens.length - 1)
+            tokens = newTokens
+        }
+
+        return tokens
+    }
+
+    String extractRememberMeCookie(Request request) {
+        Set<Cookie> cookies = request.cookies
+
+        if (!cookies) {
+            return null
+        }
+
+        Cookie cookie = cookies.find { Cookie cookie ->
+            COOKIE_NAME == cookie.name
+        }
+
+        return cookie?.value
+    }
+
+    /**
+     * Sets a "cancel cookie" (with maxAge = 0) on the response to disable persistent logins.
+     */
+    void cancelCookie(Request request, Response response) {
+        log.debug('Cancelling cookie')
+        response.expireCookie(COOKIE_NAME)
+    }
+
+    protected void setCookie(List<String> tokens, int maxAge, Request request, Response response) {
+        String cookieValue = encodeCookie(tokens)
+
+        Cookie cookie = response.cookie(COOKIE_NAME, cookieValue)
+        cookie.setMaxAge(maxAge)
+    }
+
+    /**
+     * Inverse operation of decodeCookie.
+     *
+     * @param cookieTokens the tokens to be encoded.
+     * @return base64 encoding of the tokens concatenated with the ":" delimiter.
+     */
+    protected String encodeCookie(List<String> cookieTokens) {
+        StringBuilder sb = new StringBuilder()
+        for (int i = 0; i < cookieTokens.size(); i++) {
+            sb.append(cookieTokens[i])
+
+            if (i < cookieTokens.size() - 1) {
+                sb.append(DELIMITER)
+            }
+        }
+
+        String value = sb.toString()
+
+        sb = new StringBuilder(new String(Base64.encoder.encode(value.bytes)))
+
+        while (sb.charAt(sb.length() - 1) == '=') {
+            sb.deleteCharAt(sb.length() - 1)
+        }
+
+        return sb.toString()
+    }
+}

--- a/web/src/main/groovy/com/cellarhq/common/CellarHQConfig.groovy
+++ b/web/src/main/groovy/com/cellarhq/common/CellarHQConfig.groovy
@@ -22,11 +22,12 @@ class CellarHQConfig implements Serializable {
     String databaseUser
     String databasePassword
 
+    String secretRememberMeToken
+
     final static String ENV_DEPLOYMENT_PRODUCTION = 'production'
     final static String ENV_HOSTNAME_PRODUCTION = 'www.cellarhq.com'
 
     boolean isProductionEnv() {
         return environment == ENV_DEPLOYMENT_PRODUCTION
     }
-
 }

--- a/web/src/main/resources/logback.xml
+++ b/web/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="debug">
         <appender-ref ref="STDOUT"/>
     </root>
 
@@ -44,7 +44,7 @@
 
                 <dsn>${SENTRY_DSN}</dsn>
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                    <level>ERROR</level>
+                    <level>INFO</level>
                 </filter>
             </appender>
 

--- a/web/src/ratpack/Ratpack.groovy
+++ b/web/src/ratpack/Ratpack.groovy
@@ -1,4 +1,5 @@
 import com.cellarhq.api.ApiModule
+import com.cellarhq.auth.rememberme.RememberMeService
 import com.cellarhq.common.CellarHQConfig
 import com.cellarhq.common.CommonModule
 import com.cellarhq.common.ClientErrorHandlerImpl
@@ -197,6 +198,7 @@ ratpack {
             // TODO Accessing pac4j internals...
             request.get(SessionStorage).remove(SessionConstants.USER_PROFILE)
             request.get(SessionStorage).remove(AuthenticationModule.SESSION_CELLAR_ID)
+            registry.get(RememberMeService).cancelCookie(request, response)
             redirect('/')
         }
 

--- a/web/src/ratpack/handlebars/login.html.hbs
+++ b/web/src/ratpack/handlebars/login.html.hbs
@@ -33,12 +33,18 @@
           </div>
         </div>
         <div class="form-group form-actions">
-          <div class="col-xs-6">
-            <button type="submit" class="btn btn-effect-ripple btn-primary"><i class="fa fa-check"></i> Login</button>
-          </div>
-          <div class="col-sx-6 pull-right">
-            <a class="btn" href="/forgot-password">Forgot password?</a>
-          </div>
+            <div class="col-xs-8">
+                <label class="csscheckbox csscheckbox-primary">
+                    <input type="checkbox" id="login-remember-me" name="remember-me">
+                    <span></span>
+                </label>
+                Remember Me?
+            </div>
+            <div class="col-xs-4 text-right">
+                <button type="submit" class="btn btn-effect-ripple btn-medium btn-primary">
+                    <i class="fa fa-check"></i> Login
+                </button>
+            </div>
         </div>
         <input type='hidden' id='client_name' name='client_name' value='FormClient'/>
       </form>

--- a/web/web.gradle
+++ b/web/web.gradle
@@ -156,6 +156,7 @@ task functionalTest(type: Test) {
     systemProperty 'ratpack.hostName', 'localhost:5050'
     systemProperty 'ratpack.s3StorageBucket', 'storage-local.cellarhq.com'
     systemProperty 'ratpack.environment', 'development'
+    systemProperty 'ratpack.secretRememberMeToken', 'topSecretKey'
 
 
     testClassesDir = sourceSets.functional.output.classesDir
@@ -195,8 +196,6 @@ task functionalTest(type: Test) {
             systemProperty 'ratpack.twitterApiSecret', project.twitterApiSecret
         }
     }
-
-    testLogging.showStandardStreams = true
 }
 
 
@@ -213,7 +212,7 @@ run {
     systemProperty 'ratpack.databaseName', 'cellarhq'
     systemProperty 'ratpack.databaseUser', 'cellarhq'
     systemProperty 'ratpack.databasePassword', 'cellarhq'
-
+    systemProperty 'ratpack.secretRememberMeToken', 'topSecretKey'
 
     if (project.hasProperty('awsAccessKey'))  {
         systemProperty 'ratpack.awsAccessKey', project.awsAccessKey


### PR DESCRIPTION
Needs to be conditionally added based on user preference, but it works
for twitter and email log ins.

A cookie is written containing the username and a secret hash. When
the cookie is read later, if the secret hash matches what would have
been expected for that user, then the user is automatically logged in.
